### PR TITLE
allow subsets to contain sets themselves

### DIFF
--- a/matplotlib_venn/_venn2.py
+++ b/matplotlib_venn/_venn2.py
@@ -142,6 +142,9 @@ def venn2_circles(subsets, normalize_to=1.0, alpha=1.0, color='black', linestyle
     '''
     if isinstance(subsets, dict):
         subsets = [subsets.get(t, 0) for t in ['10', '01', '11']]
+    elif len(subsets) == 2:  # objects are sets themselves
+        set1, set2 = subsets
+        subsets = [len(set1 - set2), len(set2 - set1), len(set1.intersection(set2))]
     areas = compute_venn2_areas(subsets, normalize_to)
     centers, radii = solve_venn2_circles(areas)
     
@@ -214,6 +217,9 @@ def venn2(subsets, set_labels=('A', 'B'), set_colors=('r', 'g'), alpha=0.4, norm
     '''
     if isinstance(subsets, dict):
         subsets = [subsets.get(t, 0) for t in ['10', '01', '11']]
+    elif len(subsets) == 2:  # objects are sets themselves
+        set1, set2 = subsets
+        subsets = [len(set1 - set2), len(set2 - set1), len(set1.intersection(set2))]
     areas = compute_venn2_areas(subsets, normalize_to)
     centers, radii = solve_venn2_circles(areas)
     if (areas[0] < tol or areas[1] < tol):

--- a/matplotlib_venn/_venn3.py
+++ b/matplotlib_venn/_venn3.py
@@ -396,6 +396,17 @@ def venn3_circles(subsets, normalize_to=1.0, alpha=1.0, color='black', linestyle
     # Prepare parameters
     if isinstance(subsets, dict):
         subsets = [subsets.get(t, 0) for t in ['100', '010', '110', '001', '101', '011', '111']]
+    elif len(subsets) == 3:  # objects are sets themselves
+        set1, set2, set3 = subsets
+        subsets = [
+            len(set1 - (set2.union(set3))),
+            len(set2 - (set1.union(set3))),
+            len(set1.intersection(set2) - set3),
+            len(set3 - (set1.union(set2))),
+            len(set1.intersection(set3) - set2),
+            len(set3.intersection(set2) - set1),
+            len(set1.intersection(set2).intersection(set3))
+        ]
     areas = compute_venn3_areas(subsets, normalize_to)
     centers, radii = solve_venn3_circles(areas)
     
@@ -468,6 +479,17 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
     # Prepare parameters
     if isinstance(subsets, dict):
         subsets = [subsets.get(t, 0) for t in ['100', '010', '110', '001', '101', '011', '111']]
+    elif len(subsets) == 3:  # objects are sets themselves
+        set1, set2, set3 = subsets
+        subsets = [
+            len(set1 - (set2.union(set3))),
+            len(set2 - (set1.union(set3))),
+            len(set1.intersection(set2) - set3),
+            len(set3 - (set1.union(set2))),
+            len(set1.intersection(set3) - set2),
+            len(set3.intersection(set2) - set1),
+            len(set1.intersection(set2).intersection(set3))
+        ]
 
     areas = compute_venn3_areas(subsets, normalize_to)
     if (areas[0] < tol or areas[1] < tol or areas[2] < tol):


### PR DESCRIPTION
If the number of arguments in subsets is the number of sets (i.e. 2 for
venn2 or 3 for venn3), then assume they are sets and calculate the
intersection areas using set operations.
