### PR TITLE
Add ability for matplotlib_venn to take in multisets as parameters

### DIFF
--- a/matplotlib_venn/_region.py
+++ b/matplotlib_venn/_region.py
@@ -12,7 +12,7 @@ The current logic of drawing the venn diagram is the following:
  - Compute the regions of the diagram based on circles
  - Compute the position of the label within each region.
  - Create matplotlib PathPatch or Circle objects for each of the regions.
- 
+
 This module contains functionality necessary for the second, third and fourth steps of this process.
 
 Note that the regions of an up to 3-circle Venn diagram may be of the following kinds:
@@ -44,20 +44,20 @@ class VennRegion(object):
         '''
         Given a circular region, compute two new regions:
         one obtained by subtracting the circle from this region, and another obtained by intersecting the circle with the region.
-        
+
         In all implementations it is assumed that the circle to be subtracted is not completely within
         the current region without touching its borders, i.e. it will not form a "hole" when subtracted.
-        
+
         Arguments:
            center (tuple):  A two-element tuple-like, representing the coordinates of the center of the circle.
            radius (float):  A nonnegative number, the radius of the circle.
-           
+
         Returns:
            a list with two elements - the result of subtracting the circle, and the result of intersecting with the circle.
         '''
         raise NotImplementedError("Method not implemented")
-    
-    
+
+
     def label_position(self):
         '''Compute the position of a label for this region and return it as a 1x2 numpy array (x, y).
         May return None if label is not applicable.'''
@@ -67,7 +67,7 @@ class VennRegion(object):
         '''Return a number, representing the size of the region. It is not important that the number would be a precise
         measurement, as long as sizes of various regions can be compared to choose the largest one.'''
         raise NotImplementedError("Method not implemented")
-    
+
     def make_patch(self):
         '''Create a matplotlib patch object, corresponding to this region. May return None if no patch has to be created.'''
         raise NotImplementedError("Method not implemented")
@@ -76,12 +76,12 @@ class VennRegion(object):
         '''Self-verification routine for purposes of testing. Raises a VennRegionException if some inconsistencies of internal representation
         are discovered.'''
         raise NotImplementedError("Method not implemented")
-    
+
 class VennEmptyRegion(VennRegion):
     '''
     An empty region. To save some memory, returns [self, self] on the subtract_and_intersect_circle operation.
     It is possible to create an empty region with a non-None label position, by providing it in the constructor.
-    
+
     >>> v = VennEmptyRegion()
     >>> [a, b] = v.subtract_and_intersect_circle((1,2), 3)
     >>> assert a == v and b == v
@@ -111,7 +111,7 @@ class VennEmptyRegion(VennRegion):
 class VennCircleRegion(VennRegion):
     '''
     A circle-shaped region.
-    
+
     >>> vcr = VennCircleRegion((0, 0), 1)
     >>> vcr.size()
     3.1415...
@@ -122,16 +122,16 @@ class VennCircleRegion(VennRegion):
     >>> sr, ir = vcr.subtract_and_intersect_circle((0.5, 0), 1)
     >>> assert abs(sr.size() + ir.size() - vcr.size()) < tol
     '''
-    
+
     def __init__(self, center, radius):
         self.center = np.asarray(center, float)
         self.radius = abs(radius)
         if (radius < -tol):
             raise VennRegionException("Circle with a negative radius is invalid")
-    
+
     def subtract_and_intersect_circle(self, center, radius):
         '''Will throw a VennRegionException if the circle to be subtracted is completely inside and not touching the given region.'''
-        
+
         # Check whether the target circle intersects us
         center = np.asarray(center, float)
         d = np.linalg.norm(center - self.center)
@@ -146,9 +146,9 @@ class VennCircleRegion(VennRegion):
                 raise VennRegionException("Invalid configuration of circular regions (holes are not supported).")
         else:
             # We *must* intersect the other circle. If it is not the case, then it is inside us completely,
-            # and we'll complain.            
+            # and we'll complain.
             intersections = circle_circle_intersection(self.center, self.radius, center, radius)
-            
+
             if intersections is None:
                 raise VennRegionException("Invalid configuration of circular regions (holes are not supported).")
             elif np.all(abs(intersections[0] - intersections[1]) < tol) and self.radius < radius:
@@ -170,44 +170,44 @@ class VennCircleRegion(VennRegion):
                     b_1 = b_2 - tol/2
                 if (abs(a_1 - a_2) < tol):
                     a_2 = a_1 + tol/2
-                
+
                 # The subtraction is a 2-arc-gon [(AB, B-), (BA, A+)]
                 s_arc1 = Arc(center, radius, b_1, b_2, False)
-                s_arc2 = Arc(self.center, self.radius, a_2, a_1, True)                
+                s_arc2 = Arc(self.center, self.radius, a_2, a_1, True)
                 subtraction = VennArcgonRegion([s_arc1, s_arc2])
-                
+
                 # .. and the intersection is a 2-arc-gon [(AB, A+), (BA, B+)]
                 i_arc1 = Arc(self.center, self.radius, a_1, a_2, True)
                 i_arc2 = Arc(center, radius, b_2, b_1, True)
                 intersection = VennArcgonRegion([i_arc1, i_arc2])
                 return [subtraction, intersection]
-    
+
     def size(self):
         '''
         Return the area of the circle
-        
+
         >>> VennCircleRegion((0, 0), 1).size()
         3.1415...
         >>> VennCircleRegion((0, 0), 2).size()
         12.56637...
         '''
         return np.pi * self.radius**2;
-    
+
     def label_position(self):
         '''
         The label should be positioned in the center of the circle
-        
+
         >>> VennCircleRegion((0, 0), 1).label_position()
         array([ 0.,  0.])
         >>> VennCircleRegion((-1.2, 3.4), 1).label_position()
         array([-1.2,  3.4])
         '''
         return self.center
-    
+
     def make_patch(self):
         '''
         Returns the corresponding circular patch.
-        
+
         >>> patch = VennCircleRegion((1, 2), 3).make_patch()
         >>> patch
         <matplotlib.patches.Circle object at ...>
@@ -218,7 +218,7 @@ class VennCircleRegion(VennRegion):
 
     def verify(self):
         pass
-    
+
 
 class VennArcgonRegion(VennRegion):
     '''
@@ -226,19 +226,19 @@ class VennArcgonRegion(VennRegion):
     Note that we essentially only support 2, 3 and 4 arced regions,
     whereas intersections and subtractions only work for 2-arc regions.
     '''
-    
+
     def __init__(self, arcs):
         '''
-        Create a poly-arc region given a list of Arc objects.        
+        Create a poly-arc region given a list of Arc objects.
         The arcs list must be of length 2, 3 or 4.
         The arcs must form a closed polygon, i.e. the last point of each arc must be the first point of the next arc.
         The vertices of a 3 or 4-arcgon must be listed in a CCW order. Arcs must not intersect.
-        
+
         This is not verified in the constructor, but a special verify() method can be used to check
         for validity.
         '''
         self.arcs = arcs
-        
+
     def verify(self):
         '''
         Verify the correctness of the region arcs. Throws an VennRegionException if verification fails
@@ -249,13 +249,13 @@ class VennArcgonRegion(VennRegion):
             raise VennRegionException("At least two arcs needed in a poly-arc region")
         if (len(self.arcs) > 4):
             raise VennRegionException("At most 4 arcs are supported currently for poly-arc regions")
-        
+
         TRIG_TOL = 100*tol  # We need to use looser tolerance level here because conversion to angles and back is prone to large errors.
         # Verify connectedness of arcs
         for i in range(len(self.arcs)):
             if not np.all(self.arcs[i-1].end_point() - self.arcs[i].start_point() < TRIG_TOL):
                 raise VennRegionException("Arcs of an poly-arc-gon must be connected via endpoints")
-        
+
         # Verify that arcs do not cross-intersect except at endpoints
         for i in range(len(self.arcs)-1):
             for j in range(i+1, len(self.arcs)):
@@ -263,12 +263,12 @@ class VennArcgonRegion(VennRegion):
                 for ip in ips:
                     if not (np.all(abs(ip - self.arcs[i].start_point()) < TRIG_TOL) or np.all(abs(ip - self.arcs[i].end_point()) < TRIG_TOL)):
                         raise VennRegionException("Arcs of a poly-arc-gon may only intersect at endpoints")
-                
+
                 if len(ips) != 0 and (i - j) % len(self.arcs) > 1 and (j - i) % len(self.arcs) > 1:
                     # Two non-consecutive arcs intersect. This is in general not good, but
                     # may occasionally happen when all arcs inbetween have length 0.
                     pass # raise VennRegionException("Non-consecutive arcs of a poly-arc-gon may not intersect")
-        
+
         # Verify that vertices are ordered so that at each point the direction along the polyarc changes towards the left.
         # Note that this test only makes sense for polyarcs obtained using circle intersections & subtractions.
         # A "flower-like" polyarc may have its vertices ordered counter-clockwise yet the direction would turn to the right at each of them.
@@ -277,17 +277,17 @@ class VennArcgonRegion(VennRegion):
             cur_arc = self.arcs[i]
             if box_product(prev_arc.direction_vector(prev_arc.to_angle), cur_arc.direction_vector(cur_arc.from_angle)) < -tol:
                 raise VennRegionException("Arcs must be ordered so that the direction at each vertex changes counter-clockwise")
-        
+
     def subtract_and_intersect_circle(self, center, radius):
         '''
         Circle subtraction / intersection only supported by 2-gon regions, otherwise a VennRegionException is thrown.
         In addition, such an exception will be thrown if the circle to be subtracted is completely within the region and forms a "hole".
-        
+
         The result may be either a VennArcgonRegion or a VennMultipieceRegion (the latter happens when the circle "splits" a crescent in two).
         '''
         if len(self.arcs) != 2:
             raise VennRegionException("Circle subtraction and intersection with poly-arc regions is currently only supported for 2-arc-gons.")
-        
+
         # In the following we consider the 2-arc-gon case.
         # Before we do anything, we check for a special case, where the circle of interest is one of the two circles forming the arcs.
         # In this case we can determine the answer quite easily.
@@ -295,7 +295,7 @@ class VennArcgonRegion(VennRegion):
         if len(matching_arcs) != 0:
             # If the circle matches a positive arc, the result is [empty, self], otherwise [self, empty]
             return [VennEmptyRegion(), self] if matching_arcs[0].direction else [self, VennEmptyRegion()]
-            
+
         # Consider the intersection points of the circle with the arcs.
         # If any of the intersection points corresponds exactly to any of the arc's endpoints, we will end up with
         # a lot of messy special cases (as if the usual situation is not messy enough, eh).
@@ -314,7 +314,7 @@ class VennArcgonRegion(VennRegion):
                 break
             else:
                 radius += tol
-                
+
 
         # There must be an even number of those points in total.
         # (If this is not the case, then we have an unfortunate case with weird numeric errors [TODO: find examples and deal with it?]).
@@ -349,7 +349,7 @@ class VennArcgonRegion(VennRegion):
         #           result_intersection = {X intersection to end, Y start to intersecton, intersection to intersecion along circle (positive)}
         center = np.asarray(center)
         intersections = [a.intersect_circle(center, radius) for a in self.arcs]
-        
+
         if len(intersections[0]) == 0 and len(intersections[1]) == 0:
             # Case I
             if point_in_circle(self.arcs[0].start_point(), center, radius):
@@ -361,7 +361,7 @@ class VennArcgonRegion(VennRegion):
         elif len(intersections[0]) == 2 and len(intersections[1]) == 2:
             # Case II. a) or b)
             case_II_a = not point_in_circle(self.arcs[0].start_point(), center, radius)
-            
+
             a1 = self.arcs[0].subarc_between_points(None, intersections[0][0])
             a2 = Arc(center, radius,
                      vector_angle_in_degrees(intersections[0][0] - center),
@@ -370,7 +370,7 @@ class VennArcgonRegion(VennRegion):
             a2.fix_360_to_0()
             a3 = self.arcs[1].subarc_between_points(intersections[1][1], None)
             piece1 = VennArcgonRegion([a1, a2, a3])
-            
+
             b1 = self.arcs[1].subarc_between_points(None, intersections[1][0])
             b2 = Arc(center, radius,
                      vector_angle_in_degrees(intersections[1][0] - center),
@@ -379,15 +379,15 @@ class VennArcgonRegion(VennRegion):
             b2.fix_360_to_0()
             b3 = self.arcs[0].subarc_between_points(intersections[0][1], None)
             piece2 = VennArcgonRegion([b1, b2, b3])
-            
+
             subtraction = VennMultipieceRegion([piece1, piece2])
-            
+
             c1 = self.arcs[0].subarc(a1.to_angle, b3.from_angle)
             c2 = b2.reversed()
             c3 = self.arcs[1].subarc(b1.to_angle, a3.from_angle)
             c4 = a2.reversed()
             intersection = VennArcgonRegion([c1, c2, c3, c4])
-            
+
             return [subtraction, intersection] if case_II_a else [intersection, subtraction]
         else:
             # Case III. Yuck.
@@ -409,12 +409,12 @@ class VennArcgonRegion(VennRegion):
                     a3 = self.arcs[x].subarc_between_points(intersections[x][1], None)
                     a4 = self.arcs[y]
                     subtraction = VennArcgonRegion([a1, a2, a3, a4])
-                    
+
                     #   result_intersection = {X i to j, circle j to i (direction = positive)}
                     b1 = self.arcs[x].subarc(a1.to_angle, a3.from_angle)
                     b2 = a2.reversed()
                     intersection = VennArcgonRegion([b1, b2])
-                    
+
                     return [subtraction, intersection]
                 else:
                     # Case III.a.2)
@@ -425,37 +425,37 @@ class VennArcgonRegion(VennRegion):
                              vector_angle_in_degrees(intersections[x][0] - center),
                              False)
                     subtraction = VennArcgonRegion([a1, a2])
-                    
+
                     #   result_intersection = {X 0 to i, circle i to j positive, X j to end, Y}
                     b1 = self.arcs[x].subarc(None, a1.from_angle)
                     b2 = a2.reversed()
                     b3 = self.arcs[x].subarc(a1.to_angle, None)
                     b4 = self.arcs[y]
                     intersection = VennArcgonRegion([b1, b2, b3, b4])
-                    
+
                     return [subtraction, intersection]
             else:
                 # Case III.b)
                 if len(intersections[0]) == 2 or len(intersections[1]) == 2:
                     warnings.warn("Numeric precision error during polyarc intersection, case IIIb. Expect wrong results.")
-                
+
                 # One of the arcs must start outside the circle, call it x
                 x = 0 if not point_in_circle(self.arcs[0].start_point(), center, radius) else 1
                 y = 1 - x
-                
+
                 a1 = self.arcs[x].subarc_between_points(None, intersections[x][0])
                 a2 = Arc(center, radius,
                          vector_angle_in_degrees(intersections[x][0] - center),
                          vector_angle_in_degrees(intersections[y][0] - center), False)
                 a3 = self.arcs[y].subarc_between_points(intersections[y][0], None)
                 subtraction = VennArcgonRegion([a1, a2, a3])
-                
+
                 b1 = self.arcs[x].subarc(a1.to_angle, None)
                 b2 = self.arcs[y].subarc(None, a3.from_angle)
                 b3 = a2.reversed()
                 intersection = VennArcgonRegion([b1, b2, b3])
                 return [subtraction, intersection]
-    
+
     def label_position(self):
         # Position the label right inbetween the midpoints of the arcs
         midpoints = [a.mid_point() for a in self.arcs]
@@ -467,10 +467,10 @@ class VennArcgonRegion(VennRegion):
             lengths = [a.length_degrees() for a in self.arcs]
             avg = np.sum([mp * l for (mp, l) in zip(midpoints, lengths)], 0)
             return avg / np.sum(lengths)
-    
+
     def size(self):
         '''Return the area of the patch.
-        
+
         The area can be computed using the standard polygon area formula + signed segment areas of each arc.
         '''
         polygon_area = 0
@@ -478,7 +478,7 @@ class VennArcgonRegion(VennRegion):
             polygon_area += box_product(a.start_point(), a.end_point())
         polygon_area /= 2.0
         return polygon_area + sum([a.sign * a.segment_area() for a in self.arcs])
-    
+
     def make_patch(self):
         '''
         Retuns a matplotlib PathPatch representing the current region.
@@ -504,7 +504,7 @@ class VennMultipieceRegion(VennRegion):
     Although subtraction/intersection are straightforward to implement we do
     not need those for matplotlib-venn, we raise exceptions in those methods.
     '''
-    
+
     def __init__(self, pieces):
         '''
         Create a multi-piece region from a list of VennRegion objects.
@@ -512,7 +512,7 @@ class VennMultipieceRegion(VennRegion):
         VennEmptyRegion or a single region of the necessary type.
         '''
         self.pieces = pieces
-        
+
     def label_position(self):
         '''
         Find the largest region and position the label in that.
@@ -520,10 +520,10 @@ class VennMultipieceRegion(VennRegion):
         reg_sizes = [(r.size(), r) for r in self.pieces]
         reg_sizes.sort()
         return reg_sizes[-1][1].label_position()
-    
+
     def size(self):
         return sum([p.size() for p in self.pieces])
-    
+
     def make_patch(self):
         '''Currently only works if all the pieces are Arcgons.
            In this case returns a multiple-piece path. Otherwise throws an exception.'''
@@ -531,9 +531,7 @@ class VennMultipieceRegion(VennRegion):
         vertices = np.concatenate([p.vertices for p in paths])
         codes = np.concatenate([p.codes for p in paths])
         return PathPatch(Path(vertices, codes))
-    
+
     def verify(self):
         for p in self.pieces:
             p.verify()
-        
-    

--- a/matplotlib_venn/_venn3.py
+++ b/matplotlib_venn/_venn3.py
@@ -7,6 +7,8 @@ http://kt.era.ee/
 
 Licensed under MIT license.
 '''
+from collections import Counter
+
 import numpy as np
 import warnings
 
@@ -26,7 +28,7 @@ def compute_venn3_areas(diagram_areas, normalize_to=1.0, _minimal_area=1e-6):
      (Abc, aBc, ABc, abC, AbC, aBC, ABC)
     (i.e. last element corresponds to the size of intersection A&B&C).
     The return value is a list of areas (A_a, A_b, A_c, A_ab, A_bc, A_ac, A_abc),
-    such that the total area of all circles is normalized to normalize_to. 
+    such that the total area of all circles is normalized to normalize_to.
     If the area of any circle is smaller than _minimal_area, makes it equal to _minimal_area.
 
     Assumes all input values are nonnegative (to be more precise, all areas are passed through and abs() function)
@@ -197,7 +199,7 @@ def compute_venn3_regions(centers, radii):
     aB, _ = B.subtract_and_intersect_circle(A.center, A.radius)
     aBc, aBC = aB.subtract_and_intersect_circle(C.center, C.radius)
     aC, _ = C.subtract_and_intersect_circle(A.center, A.radius)
-    abC, _ = aC.subtract_and_intersect_circle(B.center, B.radius)    
+    abC, _ = aC.subtract_and_intersect_circle(B.center, B.radius)
     return [Abc, aBc, ABc, abC, AbC, aBC, ABC]
 
 
@@ -217,10 +219,10 @@ def compute_venn3_colors(set_colors):
 
 def compute_venn3_subsets(a, b, c):
     '''
-    Given three set objects, computes the sizes of (a & ~b & ~c, ~a & b & ~c, a & b & ~c, ....), 
+    Given three set objects, computes the sizes of (a & ~b & ~c, ~a & b & ~c, a & b & ~c, ....),
     as needed by the subsets parameter of venn3 and venn3_circles.
     Returns the result as a tuple.
-    
+
     >>> compute_venn3_subsets(set([1,2,3]), set([2,3,4]), set([3,4,5,6]))
     (1, 0, 1, 2, 0, 1, 1)
     >>> compute_venn3_subsets(set([]), set([]), set([]))
@@ -236,13 +238,25 @@ def compute_venn3_subsets(a, b, c):
     >>> compute_venn3_subsets(set([1,3,5,7]), set([2,3,6,7]), set([4,5,6,7]))
     (1, 1, 1, 1, 1, 1, 1)
     '''
-    return (len(a - (b.union(c))),  # TODO: This is certainly not the most efficient way to compute.
-        len(b - (a.union(c))),
-        len(a.intersection(b) - c),
-        len(c - (a.union(b))),
-        len(a.intersection(c) - b),
-        len(b.intersection(c) - a),
-        len(a.intersection(b).intersection(c)))
+    if not ((type(a) == type(b) == type(c) == set) or (type(a) == type(b) == type(c) == Counter)):
+        raise Exception("The subsets must be either of type set or Counter.")
+    else:
+        if type(a) == type(b) == type(c) == set:
+            return (len(a - (b.union(c))),  # TODO: This is certainly not the most efficient way to compute.
+                len(b - (a.union(c))),
+                len(a.intersection(b) - c),
+                len(c - (a.union(b))),
+                len(a.intersection(c) - b),
+                len(b.intersection(c) - a),
+                len(a.intersection(b).intersection(c)))
+        else:
+            return (sum((a - (b | c)).values()),  # TODO: This is certainly not the most efficient way to compute.
+                sum((b - (a | c)).values()),
+                sum(((a & b) - c).values()),
+                sum((c - (a | b)).values()),
+                sum(((a & c) - b).values()),
+                sum(((b & c) - a).values()),
+                sum((a & b & c).values()))
 
 
 def venn3_circles(subsets, normalize_to=1.0, alpha=1.0, color='black', linestyle='solid', linewidth=2.0, ax=None, **kwargs):
@@ -261,10 +275,10 @@ def venn3_circles(subsets, normalize_to=1.0, alpha=1.0, color='black', linestyle
         subsets = [subsets.get(t, 0) for t in ['100', '010', '110', '001', '101', '011', '111']]
     elif len(subsets) == 3:
         subsets = compute_venn3_subsets(*subsets)
-        
+
     areas = compute_venn3_areas(subsets, normalize_to)
     centers, radii = solve_venn3_circles(areas)
-    
+
     if ax is None:
         ax = gca()
     prepare_venn_axes(ax, centers, radii)
@@ -298,7 +312,7 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
     The ``ax`` parameter specifies the axes on which the plot will be drawn (None means current axes).
 
     Note: if some of the circles happen to have zero area, you will probably not get a nice picture.
-    
+
     >>> import matplotlib # (The first two lines prevent the doctest from falling when TCL not installed. Not really necessary in most cases)
     >>> matplotlib.use('Agg')
     >>> from matplotlib_venn import *
@@ -308,7 +322,7 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
     >>> v.get_patch_by_id('100').set_color('white')
     >>> v.get_label_by_id('100').set_text('Unknown')
     >>> v.get_label_by_id('C').set_text('Set C')
-    
+
     You can provide sets themselves rather than subset sizes:
     >>> v = venn3(subsets=[set([1,2]), set([2,3,4,5]), set([4,5,6,7,8,9,10,11])])
     >>> print("%0.2f %0.2f %0.2f" % (v.get_circle_radius(0), v.get_circle_radius(1)/v.get_circle_radius(0), v.get_circle_radius(2)/v.get_circle_radius(0)))
@@ -325,13 +339,13 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
     centers, radii = solve_venn3_circles(areas)
     regions = compute_venn3_regions(centers, radii)
     colors = compute_venn3_colors(set_colors)
-    
+
     # Remove regions that are too small from the diagram
     MIN_REGION_SIZE = 1e-4
     for i in range(len(regions)):
         if regions[i].size() < MIN_REGION_SIZE and subsets[i] == 0:
             regions[i] = VennEmptyRegion()
-    
+
     # There is a rare case (Issue #12) when the middle region is visually empty
     # (the positioning of the circles does not let them intersect), yet the corresponding value is not 0.
     # we address it separately here by positioning the label of that empty region in a custom way
@@ -343,7 +357,7 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
     if ax is None:
         ax = gca()
     prepare_venn_axes(ax, centers, radii)
-    
+
     # Create and add patches and text
     patches = [r.make_patch() for r in regions]
     for (p, c) in zip(patches, colors):
@@ -352,7 +366,7 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
             p.set_edgecolor('none')
             p.set_alpha(alpha)
             ax.add_patch(p)
-    label_positions = [r.label_position() for r in regions]    
+    label_positions = [r.label_position() for r in regions]
     subset_labels = [ax.text(lbl[0], lbl[1], str(s), va='center', ha='center') if lbl is not None else None for (lbl, s) in zip(label_positions, subsets)]
 
     # Position labels


### PR DESCRIPTION
I've been using your package for a while, and recently I tried to draw a 3 way Venn Diagram, except that all three of the sets I had had duplicate elements. It would be possible to use either of the current APIs to draw the diagram, but it would be quite tedious either way, as I would either have to enumerate the duplicate elements or something like that if I were to use the list of sets, or I would have to compute 7 different numbers. Therefore, I propose allowing the user to enter a list of multisets (collections.Counter) as input parameters as well. An example is as follows:

>>> from collections import Counter
>>> from matplotlib_venn import venn2, venn3
>>> import matplotlib.pyplot as plt
>>> a = Counter([1,1,1,2,2,3,4])
>>> b = Counter([1,1,2,4,5])
>>> c = Counter([2,2,3,3,4,4,5,5,5,5,6])
>>> venn_1 = venn2(subsets = [a,b], set_labels = ["a", "b"])
>>>plt.show()
>>> venn_2 = venn3(subsets = [a,b,c], set_labels = ["a", "b", "c"])
>>> plt.show()
