### PR TITLE
Add parameter to allow formatting of labels of subset sizes

### DIFF
--- a/matplotlib_venn/_venn2.py
+++ b/matplotlib_venn/_venn2.py
@@ -90,7 +90,7 @@ def compute_venn2_regions(centers, radii):
     '''
     Returns a triple of VennRegion objects, describing the three regions of the diagram, corresponding to sets
     (Ab, aB, AB)
-    
+
     >>> centers, radii = solve_venn2_circles((1, 1, 0.5))
     >>> regions = compute_venn2_regions(centers, radii)
     '''
@@ -118,7 +118,7 @@ def compute_venn2_subsets(a, b):
     '''
     Given two set or Counter objects, computes the sizes of (a & ~b, b & ~a, a & b).
     Returns the result as a tuple.
-    
+
     >>> compute_venn2_subsets(set([1,2,3,4]), set([2,3,4,5,6]))
     (1, 2, 3)
     >>> compute_venn2_subsets(Counter([1,2,3,4]), Counter([2,3,4,5,6]))
@@ -168,7 +168,7 @@ def venn2_circles(subsets, normalize_to=1.0, alpha=1.0, color='black', linestyle
         subsets = compute_venn2_subsets(*subsets)
     areas = compute_venn2_areas(subsets, normalize_to)
     centers, radii = solve_venn2_circles(areas)
-    
+
     if ax is None:
         ax = gca()
     prepare_venn_axes(ax, centers, radii)
@@ -180,7 +180,7 @@ def venn2_circles(subsets, normalize_to=1.0, alpha=1.0, color='black', linestyle
     return result
 
 
-def venn2(subsets, set_labels=('A', 'B'), set_colors=('r', 'g'), alpha=0.4, normalize_to=1.0, ax=None):
+def venn2(subsets, set_labels=('A', 'B'), set_colors=('r', 'g'), alpha=0.4, normalize_to=1.0, ax=None, subset_label_formatter=None):
     '''Plots a 2-set area-weighted Venn diagram.
     The subsets parameter can be one of the following:
      - A list (or a tuple) containing two set objects.
@@ -198,9 +198,12 @@ def venn2(subsets, set_labels=('A', 'B'), set_colors=('r', 'g'), alpha=0.4, norm
     with the overall fiture size) may be useful to fit the text labels better.
     The return value is a ``VennDiagram`` object, that keeps references to the ``Text`` and ``Patch`` objects used on the plot
     and lets you know the centers and radii of the circles, if you need it.
-    
+
     The ``ax`` parameter specifies the axes on which the plot will be drawn (None means current axes).
-    
+
+    The ``subset_label_formatter`` parameter is a function that can be passed to format the labels
+    that describe the size of each subset.
+
     >>> from matplotlib_venn import *
     >>> v = venn2(subsets={'10': 1, '01': 1, '11': 1}, set_labels = ('A', 'B'))
     >>> c = venn2_circles(subsets=(1, 1, 1), linestyle='dashed')
@@ -208,7 +211,7 @@ def venn2(subsets, set_labels=('A', 'B'), set_colors=('r', 'g'), alpha=0.4, norm
     >>> v.get_patch_by_id('10').set_color('white')
     >>> v.get_label_by_id('10').set_text('Unknown')
     >>> v.get_label_by_id('A').set_text('Set A')
-    
+
     You can provide sets themselves rather than subset sizes:
     >>> v = venn2(subsets=[set([1,2]), set([2,3,4,5])], set_labels = ('A', 'B'))
     >>> c = venn2_circles(subsets=[set([1,2]), set([2,3,4,5])], linestyle='dashed')
@@ -219,6 +222,10 @@ def venn2(subsets, set_labels=('A', 'B'), set_colors=('r', 'g'), alpha=0.4, norm
         subsets = [subsets.get(t, 0) for t in ['10', '01', '11']]
     elif len(subsets) == 2:
         subsets = compute_venn2_subsets(*subsets)
+
+    if subset_label_formatter is None:
+        subset_label_formatter = str
+
     areas = compute_venn2_areas(subsets, normalize_to)
     centers, radii = solve_venn2_circles(areas)
     regions = compute_venn2_regions(centers, radii)
@@ -227,7 +234,7 @@ def venn2(subsets, set_labels=('A', 'B'), set_colors=('r', 'g'), alpha=0.4, norm
     if ax is None:
         ax = gca()
     prepare_venn_axes(ax, centers, radii)
-    
+
     # Create and add patches and subset labels
     patches = [r.make_patch() for r in regions]
     for (p, c) in zip(patches, colors):
@@ -237,7 +244,7 @@ def venn2(subsets, set_labels=('A', 'B'), set_colors=('r', 'g'), alpha=0.4, norm
             p.set_alpha(alpha)
             ax.add_patch(p)
     label_positions = [r.label_position() for r in regions]
-    subset_labels = [ax.text(lbl[0], lbl[1], str(s), va='center', ha='center') if lbl is not None else None for (lbl, s) in zip(label_positions, subsets)]
+    subset_labels = [ax.text(lbl[0], lbl[1], subset_label_formatter(s), va='center', ha='center') if lbl is not None else None for (lbl, s) in zip(label_positions, subsets)]
 
     # Position set labels
     if set_labels is not None:

--- a/matplotlib_venn/_venn3.py
+++ b/matplotlib_venn/_venn3.py
@@ -27,7 +27,7 @@ def compute_venn3_areas(diagram_areas, normalize_to=1.0, _minimal_area=1e-6):
      (Abc, aBc, ABc, abC, AbC, aBC, ABC)
     (i.e. last element corresponds to the size of intersection A&B&C).
     The return value is a list of areas (A_a, A_b, A_c, A_ab, A_bc, A_ac, A_abc),
-    such that the total area of all circles is normalized to normalize_to. 
+    such that the total area of all circles is normalized to normalize_to.
     If the area of any circle is smaller than _minimal_area, makes it equal to _minimal_area.
 
     Assumes all input values are nonnegative (to be more precise, all areas are passed through and abs() function)
@@ -198,7 +198,7 @@ def compute_venn3_regions(centers, radii):
     aB, _ = B.subtract_and_intersect_circle(A.center, A.radius)
     aBc, aBC = aB.subtract_and_intersect_circle(C.center, C.radius)
     aC, _ = C.subtract_and_intersect_circle(A.center, A.radius)
-    abC, _ = aC.subtract_and_intersect_circle(B.center, B.radius)    
+    abC, _ = aC.subtract_and_intersect_circle(B.center, B.radius)
     return [Abc, aBc, ABc, abC, AbC, aBC, ABC]
 
 
@@ -218,10 +218,10 @@ def compute_venn3_colors(set_colors):
 
 def compute_venn3_subsets(a, b, c):
     '''
-    Given three set or Counter objects, computes the sizes of (a & ~b & ~c, ~a & b & ~c, a & b & ~c, ....), 
+    Given three set or Counter objects, computes the sizes of (a & ~b & ~c, ~a & b & ~c, a & b & ~c, ....),
     as needed by the subsets parameter of venn3 and venn3_circles.
     Returns the result as a tuple.
-    
+
     >>> compute_venn3_subsets(set([1,2,3]), set([2,3,4]), set([3,4,5,6]))
     (1, 0, 1, 2, 0, 1, 1)
     >>> compute_venn3_subsets(Counter([1,2,3]), Counter([2,3,4]), Counter([3,4,5,6]))
@@ -281,10 +281,10 @@ def venn3_circles(subsets, normalize_to=1.0, alpha=1.0, color='black', linestyle
         subsets = [subsets.get(t, 0) for t in ['100', '010', '110', '001', '101', '011', '111']]
     elif len(subsets) == 3:
         subsets = compute_venn3_subsets(*subsets)
-        
+
     areas = compute_venn3_areas(subsets, normalize_to)
     centers, radii = solve_venn3_circles(areas)
-    
+
     if ax is None:
         ax = gca()
     prepare_venn_axes(ax, centers, radii)
@@ -296,7 +296,7 @@ def venn3_circles(subsets, normalize_to=1.0, alpha=1.0, color='black', linestyle
     return result
 
 
-def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha=0.4, normalize_to=1.0, ax=None):
+def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha=0.4, normalize_to=1.0, ax=None, subset_label_formatter=None):
     '''Plots a 3-set area-weighted Venn diagram.
     The subsets parameter can be one of the following:
      - A list (or a tuple), containing three set objects.
@@ -317,8 +317,11 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
 
     The ``ax`` parameter specifies the axes on which the plot will be drawn (None means current axes).
 
+    The ``subset_label_formatter`` parameter is a function that can be passed to format the labels
+    that describe the size of each subset.
+
     Note: if some of the circles happen to have zero area, you will probably not get a nice picture.
-    
+
     >>> import matplotlib # (The first two lines prevent the doctest from falling when TCL not installed. Not really necessary in most cases)
     >>> matplotlib.use('Agg')
     >>> from matplotlib_venn import *
@@ -328,7 +331,7 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
     >>> v.get_patch_by_id('100').set_color('white')
     >>> v.get_label_by_id('100').set_text('Unknown')
     >>> v.get_label_by_id('C').set_text('Set C')
-    
+
     You can provide sets themselves rather than subset sizes:
     >>> v = venn3(subsets=[set([1,2]), set([2,3,4,5]), set([4,5,6,7,8,9,10,11])])
     >>> print("%0.2f %0.2f %0.2f" % (v.get_circle_radius(0), v.get_circle_radius(1)/v.get_circle_radius(0), v.get_circle_radius(2)/v.get_circle_radius(0)))
@@ -341,17 +344,20 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
     elif len(subsets) == 3:
         subsets = compute_venn3_subsets(*subsets)
 
+    if subset_label_formatter is None:
+        subset_label_formatter = str
+
     areas = compute_venn3_areas(subsets, normalize_to)
     centers, radii = solve_venn3_circles(areas)
     regions = compute_venn3_regions(centers, radii)
     colors = compute_venn3_colors(set_colors)
-    
+
     # Remove regions that are too small from the diagram
     MIN_REGION_SIZE = 1e-4
     for i in range(len(regions)):
         if regions[i].size() < MIN_REGION_SIZE and subsets[i] == 0:
             regions[i] = VennEmptyRegion()
-    
+
     # There is a rare case (Issue #12) when the middle region is visually empty
     # (the positioning of the circles does not let them intersect), yet the corresponding value is not 0.
     # we address it separately here by positioning the label of that empty region in a custom way
@@ -363,7 +369,7 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
     if ax is None:
         ax = gca()
     prepare_venn_axes(ax, centers, radii)
-    
+
     # Create and add patches and text
     patches = [r.make_patch() for r in regions]
     for (p, c) in zip(patches, colors):
@@ -372,8 +378,8 @@ def venn3(subsets, set_labels=('A', 'B', 'C'), set_colors=('r', 'g', 'b'), alpha
             p.set_edgecolor('none')
             p.set_alpha(alpha)
             ax.add_patch(p)
-    label_positions = [r.label_position() for r in regions]    
-    subset_labels = [ax.text(lbl[0], lbl[1], str(s), va='center', ha='center') if lbl is not None else None for (lbl, s) in zip(label_positions, subsets)]
+    label_positions = [r.label_position() for r in regions]
+    subset_labels = [ax.text(lbl[0], lbl[1], subset_label_formatter(s), va='center', ha='center') if lbl is not None else None for (lbl, s) in zip(label_positions, subsets)]
 
     # Position labels
     if set_labels is not None:


### PR DESCRIPTION
I'm using your library to compare sets with very large numbers (numbers are also dollar numbers) so I want the venn diagram to display as something nicer like $1.3MM instead of 1301304. 

This pull request adds an additional argument to `venn2` and `venn3` that is a function that will take the subset size as a parameter and return a formatted string.